### PR TITLE
Fray 0.2.0 release

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
   id("com.ncorti.ktfmt.gradle") version "0.17.0"
   id("org.jetbrains.dokka") version "1.9.20"
   id("org.jreleaser") version "1.16.0"
+  id("com.gradleup.shadow") version "9.0.0-beta7"
 }
 
 repositories {

--- a/core/src/main/kotlin/org/pastalab/fray/core/TestRunner.kt
+++ b/core/src/main/kotlin/org/pastalab/fray/core/TestRunner.kt
@@ -10,10 +10,6 @@ class TestRunner(val config: Configuration) {
   val context = RunContext(config)
   var currentDivision = 1
 
-  init {
-    context.bootstrap()
-  }
-
   fun reportProgress(iteration: Int, bugsFound: Int) {
     if (config.isReplay) return
     if (iteration % currentDivision == 0) {

--- a/core/src/main/kotlin/org/pastalab/fray/core/command/Configuration.kt
+++ b/core/src/main/kotlin/org/pastalab/fray/core/command/Configuration.kt
@@ -236,10 +236,16 @@ data class Configuration(
   val startTime = TimeSource.Monotonic.markNow()
 
   fun saveToReportFolder(index: Int) {
-    Paths.get("$report/recording_$index").createDirectories()
-    File("$report/recording_$index/schedule.json").writeText(Json.encodeToString(scheduler))
-    File("$report/recording_$index/random.json").writeText(Json.encodeToString(randomnessProvider))
-    scheduleObservers.forEach { it.saveToReportFolder("$report/recording_$index") }
+    val path =
+        if (exploreMode) {
+          "$report/recording_$index"
+        } else {
+          "$report/recording"
+        }
+    Paths.get(path).createDirectories()
+    File("$path/schedule.json").writeText(Json.encodeToString(scheduler))
+    File("$path/random.json").writeText(Json.encodeToString(randomnessProvider))
+    scheduleObservers.forEach { it.saveToReportFolder(path) }
   }
 
   val frayLogger = FrayLogger("$report/fray.log")

--- a/core/src/main/kotlin/org/pastalab/fray/core/concurrency/HelperThread.kt
+++ b/core/src/main/kotlin/org/pastalab/fray/core/concurrency/HelperThread.kt
@@ -1,5 +1,37 @@
 package org.pastalab.fray.core.concurrency
 
-open class HelperThread(runnable: Runnable?) : Thread(runnable) {
-  constructor() : this(null)
+import org.pastalab.fray.core.utils.Utils
+
+class HelperThread : Thread("fray-helper-thread") {
+  var shouldStop = false
+  var currentRunnable: Runnable? = null
+
+  override fun run() {
+    while (!shouldStop) {
+      val job: Runnable?
+      synchronized(this) {
+        while (currentRunnable == null && !shouldStop) {
+          (this as Object).wait()
+        }
+        job = currentRunnable
+        currentRunnable = null
+      }
+      job?.run()
+    }
+  }
+
+  fun submit(runnable: Runnable) {
+    synchronized(this) {
+      Utils.verifyOrReport(currentRunnable == null, "Helper thread is already running a job")
+      currentRunnable = runnable
+      (this as Object).notify()
+    }
+  }
+
+  fun stopHelperThread() {
+    synchronized(this) {
+      shouldStop = true
+      (this as Object).notify()
+    }
+  }
 }

--- a/core/src/main/kotlin/org/pastalab/fray/core/concurrency/ReentrantReadWriteLockCache.kt
+++ b/core/src/main/kotlin/org/pastalab/fray/core/concurrency/ReentrantReadWriteLockCache.kt
@@ -1,0 +1,30 @@
+package org.pastalab.fray.core.concurrency
+
+import java.lang.ref.WeakReference
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock
+import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock
+import org.pastalab.fray.core.concurrency.primitives.ReferencedContextManager
+
+/**
+ * We need a static object to store the [ReadLock] and [WriteLock] because if the lock is created
+ * statically, we may lose track of the lock owner across test runs.
+ */
+object ReentrantReadWriteLockCache {
+  val lockCache =
+      ReferencedContextManager<WeakReference<ReentrantReadWriteLock>>({
+        throw RuntimeException("Should not be called")
+      })
+
+  fun getLock(obj: Any): ReentrantReadWriteLock? {
+    if (lockCache.hasContext(obj)) {
+      return lockCache.getContext(obj).get()
+    }
+    return null
+  }
+
+  fun registerLock(lock: ReentrantReadWriteLock) {
+    lockCache.addContext(lock.readLock(), WeakReference(lock))
+    lockCache.addContext(lock.writeLock(), WeakReference(lock))
+  }
+}

--- a/core/src/main/kotlin/org/pastalab/fray/core/concurrency/primitives/ReferencedContextManager.kt
+++ b/core/src/main/kotlin/org/pastalab/fray/core/concurrency/primitives/ReferencedContextManager.kt
@@ -14,11 +14,16 @@ class ReferencedContextManager<T>(val contextProducer: (Any) -> T) {
 
   fun getContext(obj: Any): T {
     val id = System.identityHashCode(obj)
-    if (!objMap.containsKey(id)) {
+    if (!hasContext(obj)) {
       objMap[id] = Pair(contextProducer(obj), IdentityPhantomReference(obj, queue))
       gc()
     }
     return objMap[id]!!.first
+  }
+
+  fun hasContext(obj: Any): Boolean {
+    val id = System.identityHashCode(obj)
+    return objMap.containsKey(id)
   }
 
   fun addContext(lock: Any, context: T) {

--- a/core/src/main/kotlin/org/pastalab/fray/core/utils/FrayBackgroundExecutor.kt
+++ b/core/src/main/kotlin/org/pastalab/fray/core/utils/FrayBackgroundExecutor.kt
@@ -1,0 +1,3 @@
+package org.pastalab.fray.core.utils
+
+class FrayBackgroundExecutor {}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 group=org.pastalab.fray
-version=0.1.10
+version=0.2.0
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/instrumentation/agent/build.gradle.kts
+++ b/instrumentation/agent/build.gradle.kts
@@ -2,7 +2,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 plugins {
   id("java")
   kotlin("jvm")
-  id("io.github.goooler.shadow") version "8.1.7"
+  id("com.gradleup.shadow")
 }
 
 repositories {

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -1,11 +1,11 @@
 plugins {
-    id("java")
+  id("java")
 }
 
 group = "org.pastalab.fray.test"
 
 repositories {
-    mavenCentral()
+  mavenCentral()
 }
 
 dependencies {

--- a/integration-test/src/main/java/org/pastalab/fray/test/success/rwlock/StaticReentrantReadWriteLockMultipleTests.java
+++ b/integration-test/src/main/java/org/pastalab/fray/test/success/rwlock/StaticReentrantReadWriteLockMultipleTests.java
@@ -1,0 +1,8 @@
+package org.pastalab.fray.test.success.rwlock;
+
+public class StaticReentrantReadWriteLockMultipleTests {
+    public static void main(String[] args) {
+        StaticReentrantReadWriteLockNormal.lock.readLock().lock();
+        StaticReentrantReadWriteLockNormal.lock.readLock().unlock();
+    }
+}

--- a/integration-test/src/main/java/org/pastalab/fray/test/success/rwlock/StaticReentrantReadWriteLockNormal.java
+++ b/integration-test/src/main/java/org/pastalab/fray/test/success/rwlock/StaticReentrantReadWriteLockNormal.java
@@ -1,0 +1,12 @@
+package org.pastalab.fray.test.success.rwlock;
+
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+public class StaticReentrantReadWriteLockNormal {
+    public static ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+    public static void main(String[] args) throws InterruptedException {
+        lock.readLock().lock();
+        lock.readLock().unlock();
+    }
+}

--- a/integration-test/src/test/java/org/pastalab/fray/test/FrayTestCase.java
+++ b/integration-test/src/test/java/org/pastalab/fray/test/FrayTestCase.java
@@ -74,7 +74,7 @@ public class FrayTestCase {
                     new ExecutionInfo(
                             new LambdaExecutor(() -> {
                                 try {
-                                    TestTime.main(new String[]{});
+                                    CountDownLatchDeadlockUnblockMultiThread.main(new String[]{});
                                 } catch (Exception e) {
                                     throw new RuntimeException(e);
                                 }

--- a/junit/src/main/kotlin/org/pastalab/fray/junit/junit5/annotations/ConcurrencyTest.kt
+++ b/junit/src/main/kotlin/org/pastalab/fray/junit/junit5/annotations/ConcurrencyTest.kt
@@ -16,7 +16,7 @@ import org.pastalab.fray.core.scheduler.Scheduler
 )
 @TestTemplate
 annotation class ConcurrencyTest(
-    val iterations: Int = 1,
+    val iterations: Int = 1000,
     val scheduler: KClass<out Scheduler> = POSScheduler::class,
     val name: String = SHORT_DISPLAY_NAME,
     val replay: String = ""

--- a/plugins/gradle/build.gradle.kts
+++ b/plugins/gradle/build.gradle.kts
@@ -1,14 +1,15 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 plugins {
   id("com.gradle.plugin-publish") version "1.2.1"
   kotlin("jvm")
   id("java")
+  id("com.gradleup.shadow")
 }
 
 dependencies {
   implementation("org.apache.commons:commons-compress:1.27.1")
 }
-
-version = "0.1.11"
 
 repositories {
   mavenCentral()
@@ -17,6 +18,12 @@ repositories {
 tasks.test {
   useJUnitPlatform()
 }
+
+tasks.named<ShadowJar>("shadowJar") {
+  archiveClassifier.set("")
+  relocate("org.apache.commons", "org.pastalab.fray.apache.commons")
+}
+
 
 gradlePlugin {
   website = "https://github.com/cmu-pasta/fray"

--- a/plugins/gradle/src/main/kotlin/FrayExtension.kt
+++ b/plugins/gradle/src/main/kotlin/FrayExtension.kt
@@ -1,5 +1,5 @@
 package org.pastalab.fray.gradle
 
 open class FrayExtension {
-  var version = "0.1.10"
+  var version = "0.2.0"
 }


### PR DESCRIPTION
- Cache ReentrantRewriteLocks if they are created statically
- Replace ExecutorService with a lightweight HelperThread
- Save recordings to `recording` folder if Fray is not in explore mode
- Shadow apache.common in gradle plugin