### PR TITLE
Fix Fray hang when shutdown hook is registered in test constructor.

### DIFF
--- a/junit/src/main/kotlin/org/pastalab/fray/junit/junit5/FrayExtension.kt
+++ b/junit/src/main/kotlin/org/pastalab/fray/junit/junit5/FrayExtension.kt
@@ -27,6 +27,9 @@ class FrayExtension(
       invocationContext: ReflectiveInvocationContext<Constructor<T>>,
       extensionContext: ExtensionContext
   ): T {
+    // The test class constructor is called even if the test is `disabled()`
+    // So we need to skip the constructor interception if the test is disabled.
+    if (frayJupiterContext.bugFound) return invocation.proceed()
     frayContext.config.currentIteration = index
     if (frayContext.config.currentIteration != 1) {
       frayContext.config.scheduler = frayContext.config.scheduler.nextIteration()

--- a/junit/src/test/java/org/pastalab/fray/junit/internal/thread/ShutdownHookTest.java
+++ b/junit/src/test/java/org/pastalab/fray/junit/internal/thread/ShutdownHookTest.java
@@ -1,0 +1,20 @@
+package org.pastalab.fray.junit.internal.thread;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.pastalab.fray.junit.junit5.FrayTestExtension;
+import org.pastalab.fray.junit.junit5.annotations.ConcurrencyTest;
+
+@ExtendWith(FrayTestExtension.class)
+public class ShutdownHookTest {
+
+    public ShutdownHookTest() {
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+        }));
+    }
+
+    @ConcurrencyTest
+    public void testShutdownHookWithFailureInBeforeEach() {
+        assert(false);
+    }
+}

--- a/junit/src/test/java/org/pastalab/fray/junit/internal/thread/ShutdownHookTest.java
+++ b/junit/src/test/java/org/pastalab/fray/junit/internal/thread/ShutdownHookTest.java
@@ -1,9 +1,10 @@
 package org.pastalab.fray.junit.internal.thread;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.pastalab.fray.junit.junit5.FrayTestExtension;
 import org.pastalab.fray.junit.junit5.annotations.ConcurrencyTest;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 @ExtendWith(FrayTestExtension.class)
 public class ShutdownHookTest {
@@ -15,6 +16,6 @@ public class ShutdownHookTest {
 
     @ConcurrencyTest
     public void testShutdownHookWithFailureInBeforeEach() {
-        assert(false);
+        fail("Intentional failure.");
     }
 }

--- a/junit/src/test/java/org/pastalab/fray/junit/tests/thread/ShutdownHookTest.java
+++ b/junit/src/test/java/org/pastalab/fray/junit/tests/thread/ShutdownHookTest.java
@@ -1,0 +1,23 @@
+package org.pastalab.fray.junit.tests.thread;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.testkit.engine.EngineTestKit;
+
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.testkit.engine.EventConditions.*;
+
+public class ShutdownHookTest {
+
+    @Test
+    public void testShutdownHook() {
+        EngineTestKit
+                .engine("junit-jupiter")
+                .selectors(selectClass(org.pastalab.fray.junit.internal.thread.ShutdownHookTest.class))
+                .execute()
+                .allEvents()
+                .assertThatEvents()
+                .haveExactly(1,
+                        event(test("testShutdownHookWithFailureInBeforeEach"), finishedWithFailure())
+                );
+    }
+}


### PR DESCRIPTION
Fix #173 