### PR TITLE
Improve the UI of the timeline panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- Make Fray Debugger adaptive to the IDE settings.
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Make Fray Debugger adaptive to the IDE settings.
+- Enable resizable separator to display complete thread names.
 
 ### Deprecated
 

--- a/plugins/idea/src/main/kotlin/org/pastalab/fray/idea/ui/ThreadTimelinePanel.kt
+++ b/plugins/idea/src/main/kotlin/org/pastalab/fray/idea/ui/ThreadTimelinePanel.kt
@@ -2,11 +2,13 @@ package org.pastalab.fray.idea.ui
 
 import com.intellij.ui.JBColor
 import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.scale.JBUIScale
+import com.intellij.util.ui.JBUI
+import com.intellij.util.ui.UIUtil
 import com.jetbrains.rd.util.ConcurrentHashMap
 import java.awt.BasicStroke
 import java.awt.BorderLayout
 import java.awt.Dimension
-import java.awt.Font
 import java.awt.Graphics
 import java.awt.Graphics2D
 import java.awt.RenderingHints
@@ -56,17 +58,19 @@ class ThreadTimelinePanel : JPanel() {
   }
 
   inner class ThreadTimelineCanvas : JPanel() {
-    private val rowHeight = 30
-    private val threadNameWidth = 105
-    private val eventWidth = 8
-    private val eventHeight = 16
-    private val eventRadius = 4
+    private val rowHeight = JBUI.scale(30)
+    private val threadNameWidth = JBUI.scale(105)
+    private val eventWidth = JBUI.scale(8)
+    private val eventHeight = JBUI.scale(16)
+    private val eventRadius = JBUI.scale(4)
+    private val eventSpacing = JBUI.scale(20)
+    private val padding = JBUI.scale(10)
 
     private var hoveredEvent: Pair<Int, Pair<Int, String>>? = null
 
     init {
       // Set a preferred size to make panel scrollable
-      preferredSize = Dimension(800, 500)
+      preferredSize = Dimension(JBUI.scale(800), JBUI.scale(500))
 
       // Add mouse listeners for interaction
       addMouseMotionListener(
@@ -89,7 +93,7 @@ class ThreadTimelinePanel : JPanel() {
                 if (y >= threadY - eventHeight && y <= threadY + eventHeight) {
                   // Check each event
                   for (event in history.events) {
-                    val eventX = threadNameWidth + (event.first * 20)
+                    val eventX = threadNameWidth + (event.first * eventSpacing)
 
                     // Use a more generous hit area for events
                     if (x >= eventX - eventWidth && x <= eventX + eventWidth) {
@@ -131,10 +135,12 @@ class ThreadTimelinePanel : JPanel() {
     }
 
     override fun getPreferredSize(): Dimension {
-      val height = maxOf(500, (threadExecutionHistory.size + 1) * rowHeight)
+      val height = maxOf(JBUI.scale(500), (threadExecutionHistory.size + 1) * rowHeight)
       val maxTimeStep =
           threadExecutionHistory.values.flatMap { it.events }.maxOfOrNull { it.first } ?: 0
-      val width = maxOf(800, threadNameWidth + (maxTimeStep + 1) * 20 + 100)
+      val width =
+          maxOf(
+              JBUI.scale(800), threadNameWidth + (maxTimeStep + 1) * eventSpacing + JBUI.scale(100))
       return Dimension(width, height)
     }
 
@@ -158,6 +164,9 @@ class ThreadTimelinePanel : JPanel() {
         g2d.drawLine(0, y, width, y)
       }
 
+      val labelFont = UIUtil.getFont(UIUtil.FontSize.NORMAL, UIUtil.getLabelFont())
+      val monospaceFont = UIUtil.getFont(UIUtil.FontSize.NORMAL, UIUtil.getLabelFont())
+
       threadExecutionHistory.entries.forEachIndexed { index, entry ->
         val threadIndex = entry.key
         val history = entry.value
@@ -165,14 +174,16 @@ class ThreadTimelinePanel : JPanel() {
 
         // Draw thread name
         g2d.color = JBColor.foreground()
-        g2d.font = Font(Font.MONOSPACED, Font.PLAIN, 12)
+        g2d.font = monospaceFont
+        val metrics = g2d.fontMetrics
+        val maxChars = (threadNameWidth - padding * 2) / metrics.charWidth('m')
         val threadName =
-            if (history.threadName.length > threadNameWidth / 10) {
-              history.threadName.substring(0, threadNameWidth / 10) + "..."
+            if (history.threadName.length > maxChars) {
+              history.threadName.substring(0, maxChars) + "..."
             } else {
               history.threadName
             }
-        g2d.drawString(threadName, 10, y + 5)
+        g2d.drawString(threadName, padding, y + metrics.height / 2 - 1)
 
         // Draw timeline for this thread, copy list to avoid concurrent modification.
         drawThreadTimeline(g2d, threadIndex, history.events.toList(), y)
@@ -191,9 +202,9 @@ class ThreadTimelinePanel : JPanel() {
       // Draw connecting line for this thread's events
       if (events.size > 1) {
         g2d.color = threadColor.darker()
-        g2d.stroke = BasicStroke(1.5f)
+        g2d.stroke = BasicStroke(JBUIScale.scale(1.5f))
 
-        val points = events.map { threadNameWidth + (it.first * 20) }
+        val points = events.map { threadNameWidth + (it.first * eventSpacing) }
         for (i in 0 until points.size - 1) {
           g2d.drawLine(points[i], y, points[i + 1], y)
         }
@@ -202,7 +213,7 @@ class ThreadTimelinePanel : JPanel() {
       // Draw each execution event
       events.forEachIndexed { index, event ->
         val timeStep = event.first
-        val x = threadNameWidth + (timeStep * 20)
+        val x = threadNameWidth + (timeStep * eventSpacing)
 
         // Draw event marker
         val isHovered =
@@ -213,19 +224,19 @@ class ThreadTimelinePanel : JPanel() {
           g2d.color = JBColor.YELLOW
           g2d.fillOval(x - eventWidth / 2, y - eventHeight / 2, eventWidth, eventHeight)
           g2d.color = threadColor.darker()
-          g2d.stroke = BasicStroke(2f)
+          g2d.stroke = BasicStroke(JBUIScale.scale(2f))
           g2d.drawOval(x - eventWidth / 2, y - eventHeight / 2, eventWidth, eventHeight)
         } else {
           // Draw normal event
           g2d.color = threadColor
           g2d.fillOval(x - eventRadius, y - eventRadius, eventRadius * 2, eventRadius * 2)
           g2d.color = threadColor.darker()
-          g2d.stroke = BasicStroke(1f)
+          g2d.stroke = BasicStroke(JBUIScale.scale(1f))
           g2d.drawOval(x - eventRadius, y - eventRadius, eventRadius * 2, eventRadius * 2)
         }
 
         g2d.color = JBColor.foreground()
-        g2d.font = Font(Font.MONOSPACED, Font.PLAIN, 9)
+        g2d.font = UIUtil.getFont(UIUtil.FontSize.SMALL, UIUtil.getLabelFont())
         g2d.drawString("${index+1}", x - 3, y + eventHeight)
       }
     }

--- a/plugins/idea/src/main/kotlin/org/pastalab/fray/idea/ui/ThreadTimelinePanel.kt
+++ b/plugins/idea/src/main/kotlin/org/pastalab/fray/idea/ui/ThreadTimelinePanel.kt
@@ -16,8 +16,8 @@ import java.awt.event.MouseEvent
 import java.awt.event.MouseMotionAdapter
 import javax.swing.JPanel
 import javax.swing.ToolTipManager
-import org.pastalab.fray.idea.objects.ThreadExecutionContext
 import kotlin.math.abs
+import org.pastalab.fray.idea.objects.ThreadExecutionContext
 
 data class ThreadExecutionHistory(
     var threadName: String,
@@ -76,20 +76,21 @@ class ThreadTimelinePanel : JPanel() {
       // Set a preferred size to make panel scrollable
       preferredSize = Dimension(JBUI.scale(800), JBUI.scale(500))
 
-      addMouseListener(object : java.awt.event.MouseAdapter() {
-        override fun mousePressed(e: MouseEvent) {
-          // Check if click is near the separator
-          if (abs(e.x - separatorPosition) <= separatorDragTolerance) {
-            isDraggingSeparator = true
-            setCursor(java.awt.Cursor.getPredefinedCursor(java.awt.Cursor.E_RESIZE_CURSOR))
-          }
-        }
+      addMouseListener(
+          object : java.awt.event.MouseAdapter() {
+            override fun mousePressed(e: MouseEvent) {
+              // Check if click is near the separator
+              if (abs(e.x - separatorPosition) <= separatorDragTolerance) {
+                isDraggingSeparator = true
+                setCursor(java.awt.Cursor.getPredefinedCursor(java.awt.Cursor.E_RESIZE_CURSOR))
+              }
+            }
 
-        override fun mouseReleased(e: MouseEvent) {
-          isDraggingSeparator = false
-          setCursor(java.awt.Cursor.getDefaultCursor())
-        }
-      })
+            override fun mouseReleased(e: MouseEvent) {
+              isDraggingSeparator = false
+              setCursor(java.awt.Cursor.getDefaultCursor())
+            }
+          })
 
       // Add mouse listeners for interaction
       addMouseMotionListener(
@@ -173,7 +174,8 @@ class ThreadTimelinePanel : JPanel() {
           threadExecutionHistory.values.flatMap { it.events }.maxOfOrNull { it.first } ?: 0
       val width =
           maxOf(
-              JBUI.scale(800), separatorPosition + (maxTimeStep + 1) * eventSpacing + JBUI.scale(100))
+              JBUI.scale(800),
+              separatorPosition + (maxTimeStep + 1) * eventSpacing + JBUI.scale(100))
       return Dimension(width, height)
     }
 

--- a/plugins/idea/src/main/kotlin/org/pastalab/fray/idea/ui/ThreadTimelinePanel.kt
+++ b/plugins/idea/src/main/kotlin/org/pastalab/fray/idea/ui/ThreadTimelinePanel.kt
@@ -3,6 +3,7 @@ package org.pastalab.fray.idea.ui
 import com.intellij.ui.JBColor
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.scale.JBUIScale
+import com.intellij.util.ui.JBFont
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
 import com.jetbrains.rd.util.ConcurrentHashMap
@@ -199,8 +200,6 @@ class ThreadTimelinePanel : JPanel() {
         g2d.drawLine(0, y, width, y)
       }
 
-      val monospaceFont = UIUtil.getFont(UIUtil.FontSize.NORMAL, UIUtil.getLabelFont())
-
       threadExecutionHistory.entries.forEachIndexed { index, entry ->
         val threadIndex = entry.key
         val history = entry.value
@@ -208,7 +207,7 @@ class ThreadTimelinePanel : JPanel() {
 
         // Draw thread name
         g2d.color = JBColor.foreground()
-        g2d.font = monospaceFont
+        g2d.font = JBUI.Fonts.create(JBFont.MONOSPACED, JBUI.scaleFontSize(12.0f))
         val metrics = g2d.fontMetrics
         val maxChars = (separatorPosition - padding * 2) / metrics.charWidth('m')
         val threadName =


### PR DESCRIPTION
- Make font size adaptive to the IDE settings.
- Enable resizable separator to display complete thread names.
