### PR TITLE
Fix integration test Java version compatibility

### DIFF
--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -8,7 +8,7 @@ group = "org.pastalab.fray.test"
 
 java {
   toolchain {
-    languageVersion.set(JavaLanguageVersion.of(23))
+    languageVersion.set(JavaLanguageVersion.of(21))
   }
 }
 


### PR DESCRIPTION
## Summary
- Updates integration test Java toolchain from version 23 to 21 for compatibility with Fray's Java 21+ support requirements
- Resolves `UnsupportedClassVersionError` that was preventing integration tests from running
- All 69 integration tests now pass successfully with 100% success rate

## Test plan
- [x] Clean and rebuild integration test classes with Java 21
- [x] Verify class files are compiled with correct bytecode version (65.0 for Java 21)
- [x] Run full integration test suite: `./gradlew :integration-test:test`
- [x] Confirm all 69 tests pass without failures

🤖 Generated with [Claude Code](https://claude.ai/code)