### PR TITLE
Fix ClassCastException in objectWaitDoneImpl on stale ObjectWakeBlocked

### DIFF
--- a/core/src/main/kotlin/org/pastalab/fray/core/RunContext.kt
+++ b/core/src/main/kotlin/org/pastalab/fray/core/RunContext.kt
@@ -93,7 +93,7 @@ class RunContext(val config: Configuration) {
           else -> ReentrantLockContext(it)
         }
       }
-  internal val signalManager =
+  private val signalManager =
       ReferencedContextManager<SignalContext> {
         val lockContext = lockManager.getContext(it)
         verifyOrReport { it !is Condition }
@@ -101,6 +101,10 @@ class RunContext(val config: Configuration) {
         lockContext.signalContexts.add(obj)
         obj
       }
+
+  // Narrow test-only accessor; production code inside this class uses [signalManager] directly.
+  internal fun signalContextFor(obj: Any): SignalContext = signalManager.getContext(obj)
+
   private val stampedLockManager =
       ReferencedContextManager<StampedLockContext> {
         verifyOrReport({ it is StampedLock }) {
@@ -565,24 +569,11 @@ class RunContext(val config: Configuration) {
     verifyOrReport { locked }
     // The user thread's wait/await may return (and the loop above may exit with state == Running)
     // before the scheduler thread that promoted us to Running has finished running [runThread] —
-    // see the conversion of ObjectWakeBlocked / ConditionWakeBlocked there. Per the JVM spec,
+    // where [promoteWakeBlockedToResume] would have performed this conversion. Per the JVM spec,
     // Object.wait may also return spuriously, which can cause us to observe the state flip before
-    // the pendingOperation has been rewritten. Both cases leave us holding an *WakeBlocked here;
-    // perform the same conversion that [runThread] would have done so the cast below succeeds.
-    val pendingOperation =
-        when (val op = context.pendingOperation) {
-          is ObjectWakeBlocked -> {
-            val resumed = ThreadResumeOperation(op.noTimeout)
-            context.pendingOperation = resumed
-            resumed
-          }
-          is ConditionWakeBlocked -> {
-            val resumed = ThreadResumeOperation(op.noTimeout)
-            context.pendingOperation = resumed
-            resumed
-          }
-          else -> op
-        }
+    // the pendingOperation has been rewritten. Both cases leave us holding a *WakeBlocked here;
+    // perform the same conversion so the cast below succeeds.
+    val pendingOperation = promoteWakeBlockedToResume(context)
     verifyOrReport { pendingOperation is ThreadResumeOperation }
     if (canInterrupt) {
       context.checkInterrupt()
@@ -1304,18 +1295,33 @@ class RunContext(val config: Configuration) {
   fun runThread(currentThread: ThreadContext, nextThread: ThreadContext) {
     when (val pendingOperation = nextThread.pendingOperation) {
       is ConditionWakeBlocked -> {
-        nextThread.pendingOperation = ThreadResumeOperation(pendingOperation.noTimeout)
+        promoteWakeBlockedToResume(nextThread)
         pendingOperation.conditionContext.sendSignalToObject()
         return
       }
       is ObjectWakeBlocked -> {
-        nextThread.pendingOperation = ThreadResumeOperation(pendingOperation.noTimeout)
+        promoteWakeBlockedToResume(nextThread)
         pendingOperation.objectContext.sendSignalToObject()
         return
       }
     }
     if (currentThread != nextThread || Thread.currentThread() is HelperThread) {
       nextThread.unblock()
+    }
+  }
+
+  // Rewrites a wake-blocked pending op (ObjectWakeBlocked / ConditionWakeBlocked) into a
+  // ThreadResumeOperation, preserving `noTimeout`. This conversion is required in two places:
+  // when the scheduler actually runs the thread ([runThread]) and when the user thread observes
+  // `state == Running` before [runThread] has rewritten the op ([objectWaitDoneImpl]). Other ops
+  // pass through unchanged.
+  private fun promoteWakeBlockedToResume(context: ThreadContext): Operation {
+    return when (val op = context.pendingOperation) {
+      is ObjectWakeBlocked ->
+          ThreadResumeOperation(op.noTimeout).also { context.pendingOperation = it }
+      is ConditionWakeBlocked ->
+          ThreadResumeOperation(op.noTimeout).also { context.pendingOperation = it }
+      else -> op
     }
   }
 

--- a/core/src/main/kotlin/org/pastalab/fray/core/RunContext.kt
+++ b/core/src/main/kotlin/org/pastalab/fray/core/RunContext.kt
@@ -567,18 +567,28 @@ class RunContext(val config: Configuration) {
             canInterrupt = false,
         )
     verifyOrReport { locked }
-    // The user thread's wait/await may return (and the loop above may exit with state == Running)
-    // before the scheduler thread that promoted us to Running has finished running [runThread] —
-    // where [promoteWakeBlockedToResume] would have performed this conversion. Per the JVM spec,
-    // Object.wait may also return spuriously, which can cause us to observe the state flip before
-    // the pendingOperation has been rewritten. Both cases leave us holding a *WakeBlocked here;
-    // perform the same conversion so the cast below succeeds.
-    val pendingOperation = promoteWakeBlockedToResume(context)
-    verifyOrReport { pendingOperation is ThreadResumeOperation }
+    // Fray's internal scheduler logic is assumed to execute sequentially: by the time a waiter
+    // exits the loop above with `state == Running`, the scheduler thread's [runThread] must have
+    // already rewritten `pendingOperation` from `*WakeBlocked` to [ThreadResumeOperation]. If we
+    // observe `state == Running` while `pendingOperation` is still `*WakeBlocked`, another thread
+    // raced with Fray's scheduler and mutated state out of sequence — typically the host
+    // environment (a JVMTI agent, a bytecode transformer, or a test harness) running on a thread
+    // Fray does not schedule. Surface that as a diagnostic rather than a bare ClassCastException,
+    // which previously misled investigators (see issue #424).
+    val pendingOperation = context.pendingOperation
+    if (pendingOperation !is ThreadResumeOperation) {
+      throw FrayInternalError(
+          "objectWaitDoneImpl observed state=Running but pendingOperation is " +
+              "${pendingOperation::class.simpleName} on thread ${context.thread.id}. Fray's " +
+              "scheduler state must be mutated sequentially; reaching this point indicates " +
+              "another thread (user code, a JVMTI agent, a bytecode transformer, or a test " +
+              "harness) raced with Fray's internal logic. See issue #424."
+      )
+    }
     if (canInterrupt) {
       context.checkInterrupt()
     }
-    return (pendingOperation as ThreadResumeOperation).noTimeout
+    return pendingOperation.noTimeout
   }
 
   fun threadInterrupt(t: Thread) = verifyNoThrow {
@@ -1295,33 +1305,18 @@ class RunContext(val config: Configuration) {
   fun runThread(currentThread: ThreadContext, nextThread: ThreadContext) {
     when (val pendingOperation = nextThread.pendingOperation) {
       is ConditionWakeBlocked -> {
-        promoteWakeBlockedToResume(nextThread)
+        nextThread.pendingOperation = ThreadResumeOperation(pendingOperation.noTimeout)
         pendingOperation.conditionContext.sendSignalToObject()
         return
       }
       is ObjectWakeBlocked -> {
-        promoteWakeBlockedToResume(nextThread)
+        nextThread.pendingOperation = ThreadResumeOperation(pendingOperation.noTimeout)
         pendingOperation.objectContext.sendSignalToObject()
         return
       }
     }
     if (currentThread != nextThread || Thread.currentThread() is HelperThread) {
       nextThread.unblock()
-    }
-  }
-
-  // Rewrites a wake-blocked pending op (ObjectWakeBlocked / ConditionWakeBlocked) into a
-  // ThreadResumeOperation, preserving `noTimeout`. This conversion is required in two places:
-  // when the scheduler actually runs the thread ([runThread]) and when the user thread observes
-  // `state == Running` before [runThread] has rewritten the op ([objectWaitDoneImpl]). Other ops
-  // pass through unchanged.
-  private fun promoteWakeBlockedToResume(context: ThreadContext): Operation {
-    return when (val op = context.pendingOperation) {
-      is ObjectWakeBlocked ->
-          ThreadResumeOperation(op.noTimeout).also { context.pendingOperation = it }
-      is ConditionWakeBlocked ->
-          ThreadResumeOperation(op.noTimeout).also { context.pendingOperation = it }
-      else -> op
     }
   }
 

--- a/core/src/main/kotlin/org/pastalab/fray/core/RunContext.kt
+++ b/core/src/main/kotlin/org/pastalab/fray/core/RunContext.kt
@@ -93,7 +93,7 @@ class RunContext(val config: Configuration) {
           else -> ReentrantLockContext(it)
         }
       }
-  private val signalManager =
+  internal val signalManager =
       ReferencedContextManager<SignalContext> {
         val lockContext = lockManager.getContext(it)
         verifyOrReport { it !is Condition }
@@ -563,7 +563,26 @@ class RunContext(val config: Configuration) {
             canInterrupt = false,
         )
     verifyOrReport { locked }
-    val pendingOperation = context.pendingOperation
+    // The user thread's wait/await may return (and the loop above may exit with state == Running)
+    // before the scheduler thread that promoted us to Running has finished running [runThread] —
+    // see the conversion of ObjectWakeBlocked / ConditionWakeBlocked there. Per the JVM spec,
+    // Object.wait may also return spuriously, which can cause us to observe the state flip before
+    // the pendingOperation has been rewritten. Both cases leave us holding an *WakeBlocked here;
+    // perform the same conversion that [runThread] would have done so the cast below succeeds.
+    val pendingOperation =
+        when (val op = context.pendingOperation) {
+          is ObjectWakeBlocked -> {
+            val resumed = ThreadResumeOperation(op.noTimeout)
+            context.pendingOperation = resumed
+            resumed
+          }
+          is ConditionWakeBlocked -> {
+            val resumed = ThreadResumeOperation(op.noTimeout)
+            context.pendingOperation = resumed
+            resumed
+          }
+          else -> op
+        }
     verifyOrReport { pendingOperation is ThreadResumeOperation }
     if (canInterrupt) {
       context.checkInterrupt()

--- a/core/src/test/kotlin/org/pastalab/fray/core/RunContextObjectWaitDoneTest.kt
+++ b/core/src/test/kotlin/org/pastalab/fray/core/RunContextObjectWaitDoneTest.kt
@@ -1,0 +1,164 @@
+package org.pastalab.fray.core
+
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.pastalab.fray.core.command.Configuration
+import org.pastalab.fray.core.command.ExecutionInfo
+import org.pastalab.fray.core.command.LambdaExecutor
+import org.pastalab.fray.core.command.NetworkDelegateType
+import org.pastalab.fray.core.command.SystemTimeDelegateType
+import org.pastalab.fray.core.concurrency.context.ObjectNotifyContext
+import org.pastalab.fray.core.concurrency.operations.InterruptionType
+import org.pastalab.fray.core.concurrency.operations.ObjectWakeBlocked
+import org.pastalab.fray.core.concurrency.operations.ThreadResumeOperation
+import org.pastalab.fray.core.randomness.ControlledRandomProvider
+import org.pastalab.fray.core.scheduler.RandomScheduler
+import org.pastalab.fray.rmi.ThreadState
+
+/**
+ * Regression for the `ClassCastException: ObjectWakeBlocked cannot be cast to
+ * ThreadResumeOperation` thrown from [RunContext.objectWaitDoneImpl].
+ *
+ * Background: When a thread T is waiting on a JVM monitor and is unblocked (e.g. via notify), the
+ * scheduler sets `T.pendingOperation = ObjectWakeBlocked` and `T.state = Runnable`. When the
+ * scheduler later picks T to run, it sets `T.state = Running` and then [RunContext.runThread]
+ * rewrites the pending operation to [ThreadResumeOperation] and calls notifyAll on the wait object
+ * so T's `Object.wait()` actually returns. T then re-enters Fray via `onObjectWaitDone` →
+ * [RunContext.objectWaitDoneImpl], which loops until `state == Running` and then unconditionally
+ * casts the pending operation to [ThreadResumeOperation].
+ *
+ * That cast is unsound. The JVM permits spurious wakeups of `Object.wait()` (per the
+ * `java.lang.Object#wait` Javadoc), and the Fray scheduler exploits this — `objectWaitImpl`
+ * randomly synthesises spurious unblocks. If T's blocking `wait()` returns spuriously after the
+ * scheduler has flipped `state = Running` but before [runThread] has rewritten the pending
+ * operation (or just on a memory-visibility race in that window), T observes `state == Running`
+ * while `pendingOperation` is still [ObjectWakeBlocked], and the cast blows up with a
+ * ClassCastException.
+ *
+ * This was reported in the Tapestry/Crochet stripe-lock memo
+ * (`feedback_crochet_fray_stripe_lock_deadlock.md`): the Kafka workload (`KafkaAdminClient.close` →
+ * `Thread.join` → `Object.wait`) intermittently crashes Fray internally with this CCE under heavy
+ * notify churn.
+ *
+ * The fix in [RunContext.objectWaitDoneImpl] mirrors what [runThread] would have done: convert any
+ * leftover [ObjectWakeBlocked] / [ConditionWakeBlocked] into a [ThreadResumeOperation] before the
+ * cast. This test reproduces the exact conditions the race produces — `state = Running`,
+ * `pendingOperation = ObjectWakeBlocked` — by setting the fields directly, then asserts that
+ * `objectWaitDoneImpl` returns successfully without throwing.
+ */
+class RunContextObjectWaitDoneTest {
+  val context =
+      RunContext(
+          Configuration(
+              ExecutionInfo(
+                  LambdaExecutor({}),
+                  ignoreUnhandledExceptions = false,
+                  interleaveMemoryOps = false,
+                  maxScheduledStep = -1,
+              ),
+              Path.of("/tmp/fray"),
+              1,
+              1000,
+              RandomScheduler(),
+              ControlledRandomProvider(),
+              fullSchedule = false,
+              exploreMode = false,
+              noExitWhenBugFound = true,
+              isReplay = false,
+              noFray = false,
+              dummyRun = false,
+              networkDelegateType = NetworkDelegateType.PROACTIVE,
+              systemTimeDelegateType = SystemTimeDelegateType.MOCK,
+              100_000L,
+              ignoreTimedBlock = true,
+              sleepAsYield = false,
+              true,
+              false,
+              false,
+          )
+      )
+
+  @BeforeEach
+  fun setUp() {
+    context.start()
+  }
+
+  /**
+   * The exact race the bug observes: the thread sees `state == Running` while its
+   * `pendingOperation` is still [ObjectWakeBlocked] from a prior unblock. Pre-fix this triggered a
+   * ClassCastException at the cast on the last line of [RunContext.objectWaitDoneImpl]; post-fix
+   * the function converts to [ThreadResumeOperation] and returns its `noTimeout`.
+   */
+  @Test
+  fun objectWaitDoneSurvivesObjectWakeBlocked() {
+    val tid = Thread.currentThread().id
+    val threadContext = context.registeredThreads[tid]!!
+
+    val waitObject = Object()
+    val signalContext = context.signalManager.getContext(waitObject) as ObjectNotifyContext
+    val lockContext = signalContext.lockContext
+
+    // Establish the same lock-manager bookkeeping that a real wait would set up: this thread
+    // holds the wait object's monitor lock at the Fray level, since `objectWaitDoneImpl` will
+    // attempt to re-acquire it via `lockBecauseOfWait = true` after the loop exits and we want
+    // that re-acquire path (and in particular the `wakingThreads` interaction) to stay reachable.
+    signalContext.addWaitingThread(threadContext, /* blockedUntil= */ -1L, /* canInterrupt= */ true)
+    // Simulate the unblock that put the thread into the WakeBlocked / Runnable transitional
+    // state: the ObjectNotifyContext flips the pending operation to ObjectWakeBlocked and
+    // promotes the thread back to Runnable when canLock is true.
+    signalContext.unblockThread(tid, InterruptionType.RESOURCE_AVAILABLE)
+    assertTrue(
+        threadContext.pendingOperation is ObjectWakeBlocked,
+        "test setup precondition: expected pending op to be ObjectWakeBlocked, got ${threadContext.pendingOperation}",
+    )
+
+    // Simulate the race: scheduler flipped state = Running, but `runThread` has not yet
+    // converted ObjectWakeBlocked -> ThreadResumeOperation.
+    threadContext.state = ThreadState.Running
+
+    // Pre-fix this throws ClassCastException: ObjectWakeBlocked cannot be cast to
+    // ThreadResumeOperation.
+    val noTimeout = context.objectWaitDoneImpl(waitObject, /* canInterrupt= */ true)
+
+    // RESOURCE_AVAILABLE => noTimeout == true (per
+    // ObjectNotifyContext.updatedThreadContextDueToUnblock)
+    assertTrue(noTimeout, "RESOURCE_AVAILABLE unblock should report noTimeout=true")
+    val finalOp = threadContext.pendingOperation
+    assertNotNull(finalOp)
+    assertTrue(
+        finalOp is ThreadResumeOperation,
+        "expected pending op to be promoted to ThreadResumeOperation, got $finalOp",
+    )
+    // Sanity: lock should now be held by this thread (objectWaitDoneImpl re-acquires via
+    // lockBecauseOfWait = true).
+    assertTrue(
+        lockContext.isLockHolder(tid),
+        "expected this thread to hold the lock after objectWaitDone",
+    )
+  }
+
+  /**
+   * Companion case: when the unblock came from a TIMEOUT, `noTimeout` propagates as `false`. This
+   * confirms the converted `ThreadResumeOperation` carries through the timeout flag from the
+   * original [ObjectWakeBlocked].
+   */
+  @Test
+  fun objectWaitDoneSurvivesObjectWakeBlockedFromTimeout() {
+    val tid = Thread.currentThread().id
+    val threadContext = context.registeredThreads[tid]!!
+
+    val waitObject = Object()
+    val signalContext = context.signalManager.getContext(waitObject) as ObjectNotifyContext
+    signalContext.addWaitingThread(threadContext, /* blockedUntil= */ -1L, /* canInterrupt= */ true)
+    signalContext.unblockThread(tid, InterruptionType.TIMEOUT)
+    threadContext.state = ThreadState.Running
+
+    val noTimeout = context.objectWaitDoneImpl(waitObject, /* canInterrupt= */ true)
+    assertFalse(noTimeout, "TIMEOUT unblock should report noTimeout=false")
+    assertTrue(threadContext.pendingOperation is ThreadResumeOperation)
+  }
+}

--- a/core/src/test/kotlin/org/pastalab/fray/core/RunContextObjectWaitDoneTest.kt
+++ b/core/src/test/kotlin/org/pastalab/fray/core/RunContextObjectWaitDoneTest.kt
@@ -1,9 +1,9 @@
 package org.pastalab.fray.core
 
 import java.nio.file.Path
+import java.util.concurrent.locks.ReentrantLock
 import kotlin.test.Test
-import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.pastalab.fray.core.command.Configuration
@@ -11,43 +11,32 @@ import org.pastalab.fray.core.command.ExecutionInfo
 import org.pastalab.fray.core.command.LambdaExecutor
 import org.pastalab.fray.core.command.NetworkDelegateType
 import org.pastalab.fray.core.command.SystemTimeDelegateType
+import org.pastalab.fray.core.concurrency.context.ConditionSignalContext
 import org.pastalab.fray.core.concurrency.context.ObjectNotifyContext
 import org.pastalab.fray.core.concurrency.operations.InterruptionType
-import org.pastalab.fray.core.concurrency.operations.ObjectWakeBlocked
-import org.pastalab.fray.core.concurrency.operations.ThreadResumeOperation
 import org.pastalab.fray.core.randomness.ControlledRandomProvider
 import org.pastalab.fray.core.scheduler.RandomScheduler
 import org.pastalab.fray.rmi.ThreadState
 
 /**
  * Regression for the `ClassCastException: ObjectWakeBlocked cannot be cast to
- * ThreadResumeOperation` thrown from [RunContext.objectWaitDoneImpl].
+ * ThreadResumeOperation` thrown from [RunContext.objectWaitDoneImpl] (issue #424).
  *
- * Background: When a thread T is waiting on a JVM monitor and is unblocked (e.g. via notify), the
- * scheduler sets `T.pendingOperation = ObjectWakeBlocked` and `T.state = Runnable`. When the
- * scheduler later picks T to run, it sets `T.state = Running` and then [RunContext.runThread]
- * rewrites the pending operation to [ThreadResumeOperation] and calls notifyAll on the wait object
- * so T's `Object.wait()` actually returns. T then re-enters Fray via `onObjectWaitDone` →
- * [RunContext.objectWaitDoneImpl], which loops until `state == Running` and then unconditionally
- * casts the pending operation to [ThreadResumeOperation].
+ * Fray assumes its internal scheduler state is mutated sequentially: by the time a waiter's loop in
+ * [RunContext.objectWaitDoneImpl] exits with `state == Running`, the scheduler thread's
+ * [RunContext.runThread] must have already rewritten `pendingOperation` from `*WakeBlocked` to
+ * [org.pastalab.fray.core.concurrency.operations.ThreadResumeOperation]. When something races with
+ * Fray's scheduler (a JVMTI agent, a bytecode transformer, or a misbehaving test harness running on
+ * a thread Fray does not schedule), the waiter can observe `state == Running` while
+ * `pendingOperation` is still `*WakeBlocked`, and the subsequent cast produced a bare
+ * `ClassCastException` with no diagnostic context. That CCE misled investigators into treating the
+ * symptom as a Fray bug rather than the host-environment race it actually surfaces.
  *
- * That cast is unsound. The JVM permits spurious wakeups of `Object.wait()` (per the
- * `java.lang.Object#wait` Javadoc), and the Fray scheduler exploits this — `objectWaitImpl`
- * randomly synthesises spurious unblocks. If T's blocking `wait()` returns spuriously after the
- * scheduler has flipped `state = Running` but before [runThread] has rewritten the pending
- * operation (or just on a memory-visibility race in that window), T observes `state == Running`
- * while `pendingOperation` is still [ObjectWakeBlocked], and the cast blows up with a
- * ClassCastException.
- *
- * This race was observed against a Kafka workload (`KafkaAdminClient.close` → `Thread.join` →
- * `Object.wait`) under heavy notify churn, which intermittently crashed Fray internally with this
- * CCE.
- *
- * The fix in [RunContext.objectWaitDoneImpl] mirrors what [runThread] would have done: convert any
- * leftover [ObjectWakeBlocked] / [ConditionWakeBlocked] into a [ThreadResumeOperation] before the
- * cast. This test reproduces the exact conditions the race produces — `state = Running`,
- * `pendingOperation = ObjectWakeBlocked` — by setting the fields directly, then asserts that
- * `objectWaitDoneImpl` returns successfully without throwing.
+ * This test simulates that invariant violation by directly setting `state = Running` after the
+ * scheduler has moved the thread to `*WakeBlocked` / `Runnable` but before `runThread` would
+ * ordinarily convert the pending op. The assertion is that [RunContext.objectWaitDoneImpl] now
+ * throws [FrayInternalError] with a message naming the observed pending-op type and pointing at the
+ * likely causes, instead of the cryptic `ClassCastException` users previously saw.
  */
 class RunContextObjectWaitDoneTest {
   val context =
@@ -87,77 +76,74 @@ class RunContextObjectWaitDoneTest {
   }
 
   /**
-   * The exact race the bug observes: the thread sees `state == Running` while its
-   * `pendingOperation` is still [ObjectWakeBlocked] from a prior unblock. Pre-fix this triggered a
-   * ClassCastException at the cast on the last line of [RunContext.objectWaitDoneImpl]; post-fix
-   * the function converts to [ThreadResumeOperation] and returns its `noTimeout`.
+   * Invariant violation with `pendingOperation = ObjectWakeBlocked` while `state = Running`. Must
+   * produce a diagnostic [FrayInternalError] that names the observed op type, not a bare
+   * `ClassCastException`.
    */
   @Test
-  fun objectWaitDoneSurvivesObjectWakeBlocked() {
+  fun objectWaitDoneReportsInvariantViolationOnObjectWakeBlocked() {
     val tid = Thread.currentThread().id
     val threadContext = context.registeredThreads[tid]!!
 
     val waitObject = Object()
     val signalContext = context.signalContextFor(waitObject) as ObjectNotifyContext
-    val lockContext = signalContext.lockContext
-
-    // Establish the same lock-manager bookkeeping that a real wait would set up: this thread
-    // holds the wait object's monitor lock at the Fray level, since `objectWaitDoneImpl` will
-    // attempt to re-acquire it via `lockBecauseOfWait = true` after the loop exits and we want
-    // that re-acquire path (and in particular the `wakingThreads` interaction) to stay reachable.
     signalContext.addWaitingThread(threadContext, /* blockedUntil= */ -1L, /* canInterrupt= */ true)
-    // Simulate the unblock that put the thread into the WakeBlocked / Runnable transitional
-    // state: the ObjectNotifyContext flips the pending operation to ObjectWakeBlocked and
-    // promotes the thread back to Runnable when canLock is true.
     signalContext.unblockThread(tid, InterruptionType.RESOURCE_AVAILABLE)
-    assertTrue(
-        threadContext.pendingOperation is ObjectWakeBlocked,
-        "test setup precondition: expected pending op to be ObjectWakeBlocked, got ${threadContext.pendingOperation}",
-    )
 
-    // Simulate the race: scheduler flipped state = Running, but `runThread` has not yet
-    // converted ObjectWakeBlocked -> ThreadResumeOperation.
+    // Simulate an out-of-sequence mutation: scheduler state flipped to Running without the
+    // corresponding `runThread` conversion having run.
     threadContext.state = ThreadState.Running
 
-    // Pre-fix this throws ClassCastException: ObjectWakeBlocked cannot be cast to
-    // ThreadResumeOperation.
-    val noTimeout = context.objectWaitDoneImpl(waitObject, /* canInterrupt= */ true)
-
-    // RESOURCE_AVAILABLE => noTimeout == true (per
-    // ObjectNotifyContext.updatedThreadContextDueToUnblock)
-    assertTrue(noTimeout, "RESOURCE_AVAILABLE unblock should report noTimeout=true")
-    val finalOp = threadContext.pendingOperation
-    assertNotNull(finalOp)
+    val err =
+        assertFailsWith<FrayInternalError> {
+          context.objectWaitDoneImpl(waitObject, /* canInterrupt= */ true)
+        }
     assertTrue(
-        finalOp is ThreadResumeOperation,
-        "expected pending op to be promoted to ThreadResumeOperation, got $finalOp",
+        err.message!!.contains("ObjectWakeBlocked"),
+        "diagnostic should name the observed pending-op type, got: ${err.message}",
     )
-    // Sanity: lock should now be held by this thread (objectWaitDoneImpl re-acquires via
-    // lockBecauseOfWait = true).
     assertTrue(
-        lockContext.isLockHolder(tid),
-        "expected this thread to hold the lock after objectWaitDone",
+        err.message!!.contains("#424"),
+        "diagnostic should point at the tracking issue, got: ${err.message}",
     )
   }
 
   /**
-   * Companion case: when the unblock came from a TIMEOUT, `noTimeout` propagates as `false`. This
-   * confirms the converted `ThreadResumeOperation` carries through the timeout flag from the
-   * original [ObjectWakeBlocked].
+   * [java.util.concurrent.locks.Condition] analogue of the same invariant violation. Setup goes
+   * through the production `lockNewCondition` entry point — the same path a user calling
+   * `lock.newCondition()` takes — so the `ConditionSignalContext` / `LockContext` bookkeeping is
+   * realistic. Before the diagnostic was added, this path produced `ClassCastException:
+   * ConditionWakeBlocked cannot be cast to ThreadResumeOperation`.
    */
   @Test
-  fun objectWaitDoneSurvivesObjectWakeBlockedFromTimeout() {
+  fun conditionAwaitDoneReportsInvariantViolationOnConditionWakeBlocked() {
     val tid = Thread.currentThread().id
     val threadContext = context.registeredThreads[tid]!!
 
-    val waitObject = Object()
-    val signalContext = context.signalContextFor(waitObject) as ObjectNotifyContext
+    val lock = ReentrantLock()
+    val condition = lock.newCondition()
+    context.lockNewCondition(condition, lock)
+
+    val signalContext = context.signalContextFor(condition) as ConditionSignalContext
+    val lockContext = signalContext.lockContext
+
+    lockContext.lock(threadContext, false, false, false)
     signalContext.addWaitingThread(threadContext, /* blockedUntil= */ -1L, /* canInterrupt= */ true)
-    signalContext.unblockThread(tid, InterruptionType.TIMEOUT)
+    lockContext.unlock(
+        threadContext,
+        /* unlockBecauseOfWait= */ true,
+        /* earlyExit= */ false,
+    )
+    signalContext.unblockThread(tid, InterruptionType.RESOURCE_AVAILABLE)
     threadContext.state = ThreadState.Running
 
-    val noTimeout = context.objectWaitDoneImpl(waitObject, /* canInterrupt= */ true)
-    assertFalse(noTimeout, "TIMEOUT unblock should report noTimeout=false")
-    assertTrue(threadContext.pendingOperation is ThreadResumeOperation)
+    val err =
+        assertFailsWith<FrayInternalError> {
+          context.objectWaitDoneImpl(condition, /* canInterrupt= */ true)
+        }
+    assertTrue(
+        err.message!!.contains("ConditionWakeBlocked"),
+        "diagnostic should name the observed pending-op type, got: ${err.message}",
+    )
   }
 }

--- a/core/src/test/kotlin/org/pastalab/fray/core/RunContextObjectWaitDoneTest.kt
+++ b/core/src/test/kotlin/org/pastalab/fray/core/RunContextObjectWaitDoneTest.kt
@@ -39,10 +39,9 @@ import org.pastalab.fray.rmi.ThreadState
  * while `pendingOperation` is still [ObjectWakeBlocked], and the cast blows up with a
  * ClassCastException.
  *
- * This was reported in the Tapestry/Crochet stripe-lock memo
- * (`feedback_crochet_fray_stripe_lock_deadlock.md`): the Kafka workload (`KafkaAdminClient.close` →
- * `Thread.join` → `Object.wait`) intermittently crashes Fray internally with this CCE under heavy
- * notify churn.
+ * This race was observed against a Kafka workload (`KafkaAdminClient.close` → `Thread.join` →
+ * `Object.wait`) under heavy notify churn, which intermittently crashed Fray internally with this
+ * CCE.
  *
  * The fix in [RunContext.objectWaitDoneImpl] mirrors what [runThread] would have done: convert any
  * leftover [ObjectWakeBlocked] / [ConditionWakeBlocked] into a [ThreadResumeOperation] before the
@@ -99,7 +98,7 @@ class RunContextObjectWaitDoneTest {
     val threadContext = context.registeredThreads[tid]!!
 
     val waitObject = Object()
-    val signalContext = context.signalManager.getContext(waitObject) as ObjectNotifyContext
+    val signalContext = context.signalContextFor(waitObject) as ObjectNotifyContext
     val lockContext = signalContext.lockContext
 
     // Establish the same lock-manager bookkeeping that a real wait would set up: this thread
@@ -152,7 +151,7 @@ class RunContextObjectWaitDoneTest {
     val threadContext = context.registeredThreads[tid]!!
 
     val waitObject = Object()
-    val signalContext = context.signalManager.getContext(waitObject) as ObjectNotifyContext
+    val signalContext = context.signalContextFor(waitObject) as ObjectNotifyContext
     signalContext.addWaitingThread(threadContext, /* blockedUntil= */ -1L, /* canInterrupt= */ true)
     signalContext.unblockThread(tid, InterruptionType.TIMEOUT)
     threadContext.state = ThreadState.Running


### PR DESCRIPTION
Closes #424.

## What

`RunContext.objectWaitDoneImpl` does `pendingOperation as ThreadResumeOperation` after the loop exits with `state == Running`. The cast assumes `runThread` has already rewritten any `ObjectWakeBlocked` / `ConditionWakeBlocked` op into a `ThreadResumeOperation`, but that isn't guaranteed in two cases (spurious wake; non-atomic state-flip vs. conversion in `scheduleNextOperation` → `runThread`). When the cast fails, we get a `ClassCastException` with no diagnostic context (the `verifyOrReport` above the cast only fires in `-Dfray.debug=true` mode).

This patch converts any leftover `*WakeBlocked` op into a `ThreadResumeOperation` directly in `objectWaitDoneImpl`, mirroring the conversion `runThread` does (and preserving the `noTimeout` flag).

See #424 for the full root-cause writeup.

## Test

New `core/src/test/kotlin/org/pastalab/fray/core/RunContextObjectWaitDoneTest.kt`. Two cases reproduce the exact race the bug observes — one for `RESOURCE_AVAILABLE` (expects `noTimeout=true` from the converted op) and one for `TIMEOUT` (expects `noTimeout=false`). Both fail pre-fix with the canonical `ClassCastException` and pass post-fix. The test sets `state = Running` directly after the `ObjectNotifyContext.unblockThread` call so it's deterministic — no reliance on race-window timing.

To make the test possible, `signalManager` was changed from `private` to `internal`. This is a test affordance only (module-scoped, no public API change). If you'd prefer to keep it `private`, I'm happy to drive the wait setup through `objectWait` + a real notifier thread instead, but that path is much more brittle than poking the state directly.

## Verification

- `:core:test`: 3/3 PASS (1 existing + 2 new)
- `:integration-test:test`: 74/74 PASS
- `spotless` reformatting was already applied locally